### PR TITLE
Add Laravel 5.6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php" : ">=7.0.0",
-        "illuminate/database": "~5.5.0",
-        "illuminate/support": "~5.5.0"
+        "illuminate/database": "~5.5",
+        "illuminate/support": "~5.5"
 
     },
     "require-dev": {
-        "orchestra/testbench": "~3.5.0",
+        "orchestra/testbench": "~3.5",
         "phpunit/phpunit": "^6.3"
     },
     "autoload": {


### PR DESCRIPTION
Currently it's not possible to use this package in the latest dev version of Laravel because the version constraints are too tight. Relaxing the version constraints in `composer.json` enables the package to be tested in Laravel `5.6.x-dev` and will allow it to be used in version 5.6 once it's released.